### PR TITLE
fix groups.yml

### DIFF
--- a/installation/chmod.php
+++ b/installation/chmod.php
@@ -8,7 +8,6 @@ chmod("../modele/config/configMenu.yml", 0777);
 chmod("../modele/config/configServeur.yml", 0777);
 chmod("../modele/config/configVotes.yml", 0777);
 chmod("../modele/config/configWidgets.yml", 0777);
-chmod("../modele/config/groups.yml", 0777);
 chmod("../modele/.htpasswd", 0777);
 chmod("../controleur/.htpasswd", 0777);
 chmod("../admin/actions/.htpasswd", 0777);


### PR DESCRIPTION
On avais supprimé le groups.yml vu qu'il servait a rien. Du coup si on ne retire pas cette ligne, ca bloque l'installation du CMS